### PR TITLE
Replace getenv to superglobal

### DIFF
--- a/src/BaseResource.php
+++ b/src/BaseResource.php
@@ -24,9 +24,9 @@ class BaseResource
 
     public function __construct()
     {
-        $this->api = new Api(getenv("AUTENTIQUE_URL") ?? "");
+        $this->api = new Api($_ENV["AUTENTIQUE_URL"] ?? "");
 
-        $this->sandbox = getenv("AUTENTIQUE_DEV_MODE") ?? "false";
+        $this->sandbox = $_ENV["AUTENTIQUE_DEV_MODE"] ?? "false";
 
         $this->resourcesEnum = ResourcesEnum::class;
     }


### PR DESCRIPTION
Padronização de leitura de envs.
Utilizando `getenv` em frameworks tipo Symfony sempre retorna `false`, invalidando toda a api
Por outro lado padroniza a forma de leitura, já que em outros locais é utilizado $_ENV